### PR TITLE
Qqplot bug

### DIFF
--- a/src/outputs.jl
+++ b/src/outputs.jl
@@ -28,10 +28,8 @@ function qqplot(output, results)
     for pvalue_col ∈ pvalue_cols
         pvalues = -log10.(filter(x -> !isnan(x), results[!, pvalue_col]))
         n = length(pvalues)
-        # If only 1 non-NA p-value, exit function
-        if n <= 1 
-            return
-        end 
+        # If <= 1 non-NA p-value, qqplot! throws error
+        n > 1 || continue
         unif_quantiles = log10_uniform_quantiles(n)
         qqplot!(ax, unif_quantiles, pvalues, qqline=:identity, label=replace(string(pvalue_col), "_PVALUE" => ""))
     end
@@ -40,7 +38,7 @@ function qqplot(output, results)
     unif_quantiles = log10_uniform_quantiles(n)
     ub = log10_beta_quantiles(n, 0.025)
     lb = log10_beta_quantiles(n, 0.975)
-    band!(ax, unif_quantiles, lb, ub, color=(:grey, 0.6))
+    band!(ax, unif_quantiles, lb, ub, color=(:grey, 0.6), label = "Uncertainty") # label required for axislegend() to run on empty plot
     # Legend
     axislegend(position=:lt)
     # Save figure

--- a/src/outputs.jl
+++ b/src/outputs.jl
@@ -28,6 +28,10 @@ function qqplot(output, results)
     for pvalue_col ∈ pvalue_cols
         pvalues = -log10.(filter(x -> !isnan(x), results[!, pvalue_col]))
         n = length(pvalues)
+        # If only 1 non-NA p-value, exit function
+        if n <= 1 
+            return
+        end 
         unif_quantiles = log10_uniform_quantiles(n)
         qqplot!(ax, unif_quantiles, pvalues, qqline=:identity, label=replace(string(pvalue_col), "_PVALUE" => ""))
     end

--- a/test/outputs.jl
+++ b/test/outputs.jl
@@ -85,9 +85,9 @@ include(joinpath(TESTDIR, "testutils.jl"))
     @test tmle["EFFECT_SIZE"] == "Failed"
 
     # Check subsetted results & optional QQplot generation
-    sub_results = results[1,:]
-    qqplot(joinpath(tmpdir, "Non_existent_QQ.png"), sub_results)
-    @test !isfile(tmpdir, "Non_existent_QQ.png")
+    sub_results = results[1:1, :]
+    TargeneCore.qqplot(TargeneCore.make_filepath_from_prefix(tmpdir; filename = "Non_existent_QQ.png"), sub_results)
+    @test !isfile(joinpath(tmpdir, "Non_existent_QQ.png"))
 end
 
 end

--- a/test/outputs.jl
+++ b/test/outputs.jl
@@ -83,6 +83,11 @@ include(joinpath(TESTDIR, "testutils.jl"))
     tmle = failed_estimate["TMLE"]
     @test tmle["PVALUE"] === NaN
     @test tmle["EFFECT_SIZE"] == "Failed"
+
+    # Check subsetted results & optional QQplot generation
+    sub_results = results[1,:]
+    qqplot(joinpath(tmpdir, "Non_existent_QQ.png"), sub_results)
+    @test !isfile(tmpdir, "Non_existent_QQ.png")
 end
 
 end

--- a/test/outputs.jl
+++ b/test/outputs.jl
@@ -84,10 +84,10 @@ include(joinpath(TESTDIR, "testutils.jl"))
     @test tmle["PVALUE"] === NaN
     @test tmle["EFFECT_SIZE"] == "Failed"
 
-    # Check subsetted results & optional QQplot generation
+    # When <= 1 NA p-value present in results, check that empty QQ plot can be generated and qqplot!() does not throw error
     sub_results = results[1:1, :]
-    TargeneCore.qqplot(TargeneCore.make_filepath_from_prefix(tmpdir; filename = "Non_existent_QQ.png"), sub_results)
-    @test !isfile(joinpath(tmpdir, "Non_existent_QQ.png"))
+    TargeneCore.qqplot(TargeneCore.make_filepath_from_prefix(tmpdir; filename = "Empty_QQ.png"), sub_results)
+    @test isfile(joinpath(tmpdir, "Empty_QQ.png"))
 end
 
 end


### PR DESCRIPTION
Branch to fix bug in TargeneCore.jl in which qqplot() function threw in error when only a single p-value was present in the results. This branch checks if the number of non-NA p-values are less than or equal to 1 and does not return a QQplot.png if this is the case. Tests also added. 